### PR TITLE
modified checkService to check for regex (service starting with /)

### DIFF
--- a/includes/includes.php
+++ b/includes/includes.php
@@ -163,7 +163,7 @@ $cplogo = $config["LOGO"];
 $cpfavicon = $config["FAVICON"];
 
 // Enable / Disable Sections
-if(checkService('apache2') !== false || checkService('php-fpm') !== false) {
+if(checkService('apache2') !== false || checkService('/php(.*)-fpm/') !== false) {
     if($config["WEB_ENABLED"] != 'true'){
         $webenabled = '';
     }
@@ -678,9 +678,9 @@ function footer() {
 }
 function checkService($requestedService) {
     global $servicedata;
-    
+    if($requestedService[0] == '/') {return preg_match($requestedService, $servicedata);}
+
     if( strpos($servicedata, $requestedService) !== false ) { return true; }
     else { return false; }
-    
 }
 ?>


### PR DESCRIPTION
starting php7 the service is called php<version>-fpm
so, if we don't want to update this file on every update on the php-version, we need s.th. like a regex - since strpos unfortionatly don't comb with wildcards. 

Since `strpos` is much faster than `preg_match` we first check the first character, if it starts with a '/' - which I hope will only be the case for a following regex. 
then we decide: if yes -> regex
if no - use the faster strpos. 