### PR TITLE
Fix translation on term equivalent for "Home"

### DIFF
--- a/locale/pt_BR/LC_MESSAGES/messages.po
+++ b/locale/pt_BR/LC_MESSAGES/messages.po
@@ -2549,7 +2549,7 @@ msgstr "Erro ao atualizar conta de email"
 
 #: includes/includes.php:362
 msgid "Home"
-msgstr "Casa"
+msgstr "Início"
 
 #: includes/includes.php:371
 msgid "Administration"


### PR DESCRIPTION
Fix for "Home" term to a non-literal word.